### PR TITLE
Linux path-issue fix for tex layer.

### DIFF
--- a/src/haven/Resource.java
+++ b/src/haven/Resource.java
@@ -620,7 +620,7 @@ public class Resource {
 	    br.close();
 	    String str_id = data.getName().substring(data.getName().lastIndexOf("_") + 1, data.getName().lastIndexOf("."));
 	    int id = Integer.parseInt(str_id);
-	    String path = data.getPath().substring(0, data.getPath().lastIndexOf("\\"));
+	    String path = data.getPath().substring(0, data.getPath().lastIndexOf("/"));
 	    File img = new File(path + "/image_" + id + ".png");
 	    this.image = ImageIO.read(img);
 	    this.size = this.build().fin().length;


### PR DESCRIPTION
Changed path-separator, from windows-specific "\\\\", to general windows & Linux "/" path-separator.
Effects tex-layer only.