### PR TITLE
Order FileList alphabetically to fix wrong order in linux 

### DIFF
--- a/src/haven/Resource.java
+++ b/src/haven/Resource.java
@@ -265,6 +265,12 @@ public class Resource {
 			Class<? extends Layer> lc = (Class)ltypes.get(n);
 			if (lc != null) {
 			    File[] df = l[i].listFiles();
+			    Arrays.sort(df, new Comparator<File>(){
+				public int compare(File f1, File f2)
+				{
+				    return String.valueOf(f1.getName()).compareTo(f2.getName());
+				}
+			    });
 			    int j;
 			    Constructor cons;
 			    NoSuchMethodException e;


### PR DESCRIPTION
For whatever reason, "ListFiles" doesn't order automatically in linux (at least on my system, deb 13 with C as install language).

LayerUtil needs the files in a specific order, which is dictated by their file name.
e.g.
image_0.data
image_0.png
image_1.data
image_1.png
and so on.
So the data File needs be there first, and after that the image file.

This fix will not work if the image file is actually a file format which sorts before "data".
Since BMP is the only thing that comes to my mind, that nobody uses anyway, this should be fine.

PS: I just saw that during check in the format got fucked up a bit. Since this is just a tool it shouldn't be a huge issue...